### PR TITLE
Fix pipeline so intermediate tables are ignored

### DIFF
--- a/etl/entities_registry.py
+++ b/etl/entities_registry.py
@@ -59,6 +59,17 @@ def get_all_entities_names():
     return list(entities.keys())
 
 
+# Some entities (exceptional cases) are not to be stored into the database because they are just temporary entities
+# that help with other transformations.
+def get_all_entities_names_to_store_db():
+    entities_names_to_store_db = []
+    for k in entities:
+        if len(entities[k]["expected_database_columns"]) > 0:
+            entities_names_to_store_db.append(k)
+
+    return entities_names_to_store_db
+
+
 entities = {
     Constants.DIAGNOSIS_ENTITY: {
         "spark_job": etl.jobs.transformation.diagnosis_transformer_job.main,

--- a/etl/workflow/loader.py
+++ b/etl/workflow/loader.py
@@ -3,7 +3,7 @@ from luigi.contrib.spark import SparkSubmitTask
 import time
 
 from etl.constants import Constants
-from etl.entities_registry import get_all_entities_names
+from etl.entities_registry import get_all_entities_names, get_all_entities_names_to_store_db
 from etl.entities_task_index import get_transformation_class_by_entity_name, get_all_transformation_classes
 from etl.jobs.load.database_manager import copy_entity_to_database, get_database_connection, \
     delete_fks, delete_indexes, create_indexes, create_fks
@@ -64,7 +64,7 @@ class CopyEntityFromCsvToDb(luigi.Task):
 
 def get_all_copying_tasks():
     tasks = []
-    for entity_name in get_all_entities_names():
+    for entity_name in get_all_entities_names_to_store_db():
         tasks.append(CopyEntityFromCsvToDb(entity_name=entity_name))
     return tasks
 


### PR DESCRIPTION
- Fix in the pipeline to ignore intermediate entities (those that are not expected to be stored in the database) when executing the task to copy data into the database