### PR TITLE
Pyspark and luigi upgrade

### DIFF
--- a/etl/jobs/transformation/search_index_molecular_data_transformer_job.py
+++ b/etl/jobs/transformation/search_index_molecular_data_transformer_job.py
@@ -100,6 +100,9 @@ def transform_search_index_molecular_data(
 
     # Add hla types
     df = add_hla_types(df, search_index_molecular_char_df, immunemarkers_data_df)
+    
+    # Delete colums that get duplicate in the process
+    df = df.drop("model_id")
 
     return df
 
@@ -315,9 +318,6 @@ def join_symbols_list_to_model_df(
         model_symbols_list_per_datatype,
         on=[model_metadata_df.pdcm_model_id == model_symbols_list_per_datatype.model_id],
         how='left')
-
-    # Delete column because it is already present in the df
-    model_metadata_df = model_metadata_df.drop(model_symbols_list_per_datatype.model_id)
 
     return model_metadata_df
 

--- a/etl/jobs/util/parquet_to_tsv_converter.py
+++ b/etl/jobs/util/parquet_to_tsv_converter.py
@@ -1,6 +1,8 @@
 import sys
 
 from pyspark.sql import SparkSession
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.functions import col, when
 
 from etl.constants import Constants
 from etl.entities_registry import get_columns_by_entity_name
@@ -25,11 +27,19 @@ def main(argv):
     columns = get_columns_by_entity_name(entity)
     df = flatten_array_columns(df)
     df = df.select(columns)
+    # Null values need to be treated as empty strings so the copy to the database works
+    df = null_values_to_empty_string(df)
+    
     # df.coalesce(1).write \
     df.write.option("sep", "\t").option("quote", "\u0000").option(
         "header", "true"
     ).mode("overwrite").csv(output_path)
-
+    
+def null_values_to_empty_string(df : DataFrame):
+    for col_name in df.columns:
+        df = df.withColumn(col_name, when(col(col_name).isNull(), "").otherwise(col(col_name)))
+    return df
+    
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-luigi==3.1.1
+luigi==3.5.0
 
 #Making pyspark 3.1.1 because 3.2.0 and 3.2.1 have a bug regarding replacing a dataset view which is fixed in spark 3.2.2 but it's not available in pyspark at the moment (3.2.1)
-pyspark==3.1.1
+pyspark==3.3.3
 docutils~=0.17.1
 pip
 py4j~=0.10.9


### PR DESCRIPTION
- pyspark from 3.1.1 to 3.5.0
- luigi from 3.1.1 to 3.5.0
- Adjustments in code to fix issue with null values when writing the tsv files (due to the pyspark upgrade)